### PR TITLE
Fix: Instant previews

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ highlighter: rouge
 exclude:
   - Gemfile
   - README.md
+  - vendor/bundle
 
 plugins:
   - jekyll-feed


### PR DESCRIPTION
👋 Hi @forestryio support here,

Dependencies are added in `vendor/bundle` by default, jekyll shouldn't copy this folder to destination, this leads to a build error and prevent instant preview to work.